### PR TITLE
Filter dead media out of the scraped data

### DIFF
--- a/.github/workflows/scrape-signbank.yaml
+++ b/.github/workflows/scrape-signbank.yaml
@@ -1,6 +1,7 @@
 name: Scrape Signbank
 
-# Re-scrape auslan.org.au (Auslan Signbank) and open — or update — a
+# Re-scrape auslan.org.au (Auslan Signbank), filter out videos that 404 on the
+# media host (with an independent verification pass), and open — or update — a
 # data-update PR against master. This used to be a weekly CronJob on the home
 # k8s cluster (server-platform src/apps/dictionary.ts, now disabled); it moved
 # here so it runs on GitHub's infra, needs no home-server PAT, and can be
@@ -48,10 +49,33 @@ jobs:
 
       - name: Scrape Signbank (categories + a..z)
         working-directory: scripts
-        # scrape.sh scrapes categories.json then walks a..z into all_letters.json.
-        # It (and incremental_scrape.sh) require running under `uv run`, which
-        # sets $UV and puts the venv python on PATH.
+        # scrape.sh scrapes categories.json, walks a..z into all_letters.json,
+        # then filters out videos that 404 on the media host
+        # (filter_dead_media.py; exits non-zero rather than guess, so a flaky
+        # week fails here instead of opening a PR). It (and
+        # incremental_scrape.sh) require running under `uv run`, which sets $UV
+        # and puts the venv python on PATH.
         run: uv run bash scrape.sh
+
+      - name: Verify removed media
+        working-directory: scripts
+        # Independent double-check (different code path/pacing/timing) that
+        # every URL the filter removed authentically 404s. Fails the run —
+        # before the diff-gate, so before any PR — if a removal can't be
+        # confirmed.
+        run: |
+          uv run python verify_removed_media.py \
+            --before all_letters_prefilter.json \
+            --after all_letters.json \
+            --initial-delay 120
+
+      - name: Upload media filter report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: media-filter-report
+          path: scripts/media_filter_report/
+          if-no-files-found: ignore
 
       - name: Detect data changes
         id: detect

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Free video dictionary of Auslan signs
 
 publish_to: 'none'
 
-version: 2.0.59+970
+version: 2.0.60+971
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -4,6 +4,8 @@ previous.json
 next.json
 next_*.json
 all_letters.json
+all_letters_prefilter.json
+media_filter_report/
 scrape_state.txt
 scrape_progress.json
 .venv

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -44,8 +44,8 @@ For running locally with manual PR creation:
 ```bash
 cd scripts
 
-# Step 1: Run the full scrape
-uv run ./scrape.sh --validate |& tee ~/run-out.log
+# Step 1: Run the full scrape (includes the dead-media filter phase)
+uv run ./scrape.sh |& tee ~/run-out.log
 
 # Step 2: Review the output
 # Check all_letters.json looks correct
@@ -74,15 +74,8 @@ gh pr create --fill
 uv run ./scrape.sh
 ```
 
-This scrapes categories first, then entries letter by letter.
-
-### Scrape with Video URL Validation
-
-Validates each video URL with an OPTIONS request and removes entries with invalid videos:
-
-```bash
-uv run ./scrape.sh --validate
-```
+This scrapes categories first, then entries letter by letter, then removes
+videos that 404 on the media host (see `filter_dead_media.py` below).
 
 ### Resume an Interrupted Scrape
 
@@ -137,13 +130,36 @@ uv run python scrape_signbank.py -d \
     --urls 'https://auslan.org.au/dictionary/words/hello-1.html' \
     --categories-file ../assets/data/categories.json \
     --output-file output.json
+```
 
-# With video URL validation
-uv run python scrape_signbank.py -d \
-    --letters a \
-    --categories-file ../assets/data/categories.json \
-    --output-file output.json \
-    --validate-video-urls
+### filter_dead_media.py
+
+Removes videos that 404 on the media host from a scraped data file, pruning sub_entries/entries left empty. Run automatically as the final phase of `scrape.sh`, but works standalone on any v1-shaped file. A URL is only removed after `--dead-attempts` (default 5) authentic Swift 404s across rounds spaced `--recheck-delay` seconds apart; anything that never resolves to alive-or-dead fails the run rather than guessing. Writes full per-attempt evidence to `media_filter_report/report.json`.
+
+```bash
+# Clean the committed data in a standalone pass, extra-patient re-checks.
+uv run python filter_dead_media.py --input ../assets/data/data.json \
+    --output all_letters.json --recheck-delay 300
+```
+
+Exit codes: `0` cleaned output written; `2` too many dead URLs (`--max-dead-fraction`, output not written — protects against a host-side event gutting the dictionary); `3` some URLs never resolved (output not written).
+
+### verify_removed_media.py
+
+Independently confirms (different code path, request shape, and pacing — deliberately so) that every URL the filter removed authentically 404s. Diffs the pre-/post-filter files itself, fails (exit 1) on any removal that answers alive or can't be confirmed, and spot-checks a sample of kept URLs. CI runs it before the data-update PR can open.
+
+```bash
+uv run python verify_removed_media.py \
+    --before all_letters_prefilter.json --after all_letters.json
+```
+
+### archive_orphaned_media.py
+
+Lists R2 mirror objects that `data-v2.json` no longer references and, with `--archive`, moves them to the `archive/` prefix (server-side copy + delete — nothing is ever hard-deleted, and moving an object back undoes a mistake). Manual housekeeping, not in CI. Needs the R2 env vars from `secrets.env`, like `sync_media_to_r2.py`.
+
+```bash
+uv run python archive_orphaned_media.py            # list only
+uv run python archive_orphaned_media.py --archive  # list + move
 ```
 
 ### move_data.sh
@@ -204,11 +220,7 @@ uv run python scrape_signbank.py -d \
 
 ### Video URLs are returning errors
 
-Some video URLs on the site may be broken. Use `--validate` to filter these out:
-
-```bash
-uv run ./scrape.sh --validate
-```
+Some video URLs on the site are broken (Signbank lists videos whose objects are gone from the media host). `scrape.sh` filters these out automatically in its final phase; see `filter_dead_media.py` above. Expect the same ~1-2% of URLs to be re-removed every scrape for as long as Signbank keeps listing them.
 
 ### Rate limiting
 

--- a/scripts/archive_orphaned_media.py
+++ b/scripts/archive_orphaned_media.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+
+"""
+Find (and optionally archive) R2 mirror objects that the data no longer
+references.
+
+The auslan-mirror bucket is the app's fallback media host, populated by
+sync_media_to_r2.py from data-v2.json. When filter_dead_media.py removes a
+dead video from the data, or a sign's media path changes, the mirror can be
+left holding objects nothing references. This lists those orphans, and with
+--archive moves each from <key> to archive/<key> — out of the app's way (the
+mirror serves keys matching data-v2.json paths) but still in the bucket, so a
+mistaken archive is recoverable by moving the object back. Nothing is ever
+hard-deleted.
+
+Only keys under the media prefixes (mp4video/, auslan/) are ever candidates:
+the bucket also holds the CI data mirror under data/ and previous archives
+under archive/, and any key outside the known prefixes is reported but never
+touched.
+
+This is the Auslan analog of the SLSL admin site's find_unused_videos
+management command. That one is Django/DB-backed and deliberately SLSL-only;
+this one is driven by data-v2.json. They stay separate on purpose.
+
+Credentials come from the environment, same as sync_media_to_r2.py
+(R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY — see scripts'
+secrets.env).
+
+Usage:
+
+    # Just list the orphans (read-only).
+    uv run python archive_orphaned_media.py
+
+    # List + move them to archive/.
+    uv run python archive_orphaned_media.py --archive
+"""
+
+import argparse
+import logging
+import os
+from pathlib import Path
+
+from common import LOG
+from sync_media_to_r2 import (
+    DEFAULT_BUCKET,
+    DEFAULT_DATA_FILE,
+    collect_media_paths,
+    list_existing_keys,
+    make_s3_client,
+    r2_key_for,
+)
+
+# Where archived orphans go: a sibling prefix the app never reads.
+ARCHIVE_PREFIX = "archive/"
+
+# The only prefixes this script will ever move objects out of. data-v2.json
+# media paths span exactly these today; a new prefix showing up in the bucket
+# is surfaced for a human rather than treated as archivable.
+MEDIA_PREFIXES = ("mp4video/", "auslan/")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--data-file",
+        type=Path,
+        default=DEFAULT_DATA_FILE,
+        help=f"Path to data-v2.json (default: {DEFAULT_DATA_FILE}).",
+    )
+    parser.add_argument(
+        "--bucket",
+        default=DEFAULT_BUCKET,
+        help=f"R2 bucket name (default: {DEFAULT_BUCKET}).",
+    )
+    parser.add_argument(
+        "--archive",
+        action="store_true",
+        help="Move each orphan to archive/<key> (server-side copy then delete). "
+        "Without this flag the script only lists them.",
+    )
+    parser.add_argument("-d", "--debug", action="store_true")
+    args = parser.parse_args()
+
+    LOG.setLevel(logging.DEBUG if args.debug else logging.INFO)
+
+    if not args.data_file.exists():
+        parser.error(f"Data file not found: {args.data_file}")
+    for var in ("R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY"):
+        if not os.environ.get(var):
+            parser.error(f"Missing required env var: {var}")
+
+    referenced = {r2_key_for(path) for path in collect_media_paths(args.data_file)}
+    LOG.info(f"{len(referenced)} media paths referenced by {args.data_file}")
+
+    s3 = make_s3_client()
+    LOG.info(f"Listing objects in {args.bucket}...")
+    all_keys = list_existing_keys(s3, args.bucket)
+
+    candidates = {key for key in all_keys if key.startswith(MEDIA_PREFIXES)}
+    ignored = all_keys - candidates
+    already_archived = sum(1 for key in ignored if key.startswith(ARCHIVE_PREFIX))
+    other_ignored = sorted(
+        key
+        for key in ignored
+        if not key.startswith(ARCHIVE_PREFIX) and not key.startswith("data/")
+    )
+    LOG.info(
+        f"{len(all_keys)} objects in bucket: {len(candidates)} media, "
+        f"{already_archived} already archived, "
+        f"{len(ignored) - already_archived} outside the media prefixes"
+    )
+    if other_ignored:
+        LOG.warning(
+            f"{len(other_ignored)} keys outside every known prefix "
+            f"(never touched, but worth a look): {other_ignored[:10]}"
+        )
+
+    orphans = sorted(candidates - referenced)
+    missing = referenced - candidates
+    if missing:
+        # The inverse (data pointing at objects the mirror lacks) is a separate
+        # concern (sync_media_to_r2.py), surfaced so a clean orphan count isn't
+        # mistaken for a fully healthy mirror.
+        LOG.warning(
+            f"(also {len(missing)} referenced paths with no object in the bucket "
+            f"— run sync_media_to_r2.py)"
+        )
+
+    for key in orphans:
+        LOG.info(f"  orphan: {key}")
+    LOG.info(f"{len(orphans)} orphaned media objects")
+
+    if not args.archive:
+        if orphans:
+            LOG.info("Re-run with --archive to move these to the archive/ prefix.")
+        return 0
+
+    moved = 0
+    failed = 0
+    for key in orphans:
+        dst_key = f"{ARCHIVE_PREFIX}{key}"
+        try:
+            # Server-side copy, then delete the original: an S3/R2 "move".
+            s3.copy_object(
+                Bucket=args.bucket,
+                CopySource={"Bucket": args.bucket, "Key": key},
+                Key=dst_key,
+            )
+            s3.delete_object(Bucket=args.bucket, Key=key)
+        except Exception as e:
+            LOG.error(f"Failed to archive {key}: {e}")
+            failed += 1
+            continue
+        moved += 1
+        LOG.info(f"  archived: {key} -> {dst_key}")
+
+    LOG.info(
+        f"Archived {moved}/{len(orphans)} orphans"
+        + (f", {failed} failed" if failed else "")
+    )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/backup_videos.py
+++ b/scripts/backup_videos.py
@@ -36,7 +36,6 @@ import argparse
 import json
 import logging
 import os
-import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from email.utils import parsedate_to_datetime
 from pathlib import Path
@@ -46,7 +45,7 @@ from urllib.parse import urlsplit
 import requests
 from retry import retry
 
-from common import LOG, DEFAULT_TIMEOUT, _rate_limit
+from common import LOG, DEFAULT_TIMEOUT, _rate_limit, _respect_retry_after
 
 # Retry config for network calls. The source object store is slow and flaky, so
 # we retry generously with exponential backoff (1s, 2s, 4s, ... capped at 120s).
@@ -59,10 +58,6 @@ RETRY_KWARGS = dict(
     tries=12,
     logger=LOG,
 )
-
-# Cap on how long we'll honor a server's Retry-After header (seconds), so a
-# pathological value can't stall a worker indefinitely.
-RETRY_AFTER_CAP = 120
 
 # Default location of the scraped data relative to this script (scripts/ ->
 # repo root -> assets/data/data.json).
@@ -79,29 +74,6 @@ CHUNK_SIZE = 1 << 16  # 64 KiB.
 
 class VideoNotFound(Exception):
     """Raised when a video URL returns 404. Deliberately not retried."""
-
-
-def _respect_retry_after(response):
-    """
-    If the server sent a Retry-After header (typically with a 429 or 503),
-    sleep for the requested duration (capped) so we back off politely. Supports
-    both the integer-seconds and HTTP-date forms of the header.
-    """
-    header = response.headers.get("Retry-After")
-    if not header:
-        return
-    delay = None
-    try:
-        delay = float(header)
-    except ValueError:
-        try:
-            delay = parsedate_to_datetime(header).timestamp() - time.time()
-        except (TypeError, ValueError):
-            delay = None
-    if delay and delay > 0:
-        delay = min(delay, RETRY_AFTER_CAP)
-        LOG.warning(f"Server asked us to back off; sleeping {delay:.0f}s (Retry-After)")
-        time.sleep(delay)
 
 
 def collect_video_urls(data_file: Path) -> list:

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import time
+from email.utils import parsedate_to_datetime
 from typing import List, Optional
 
 import requests
@@ -35,7 +36,28 @@ def strip_media_base(url: str) -> str:
             f"{MEDIA_BASE_URL!r}: {url!r}. If Auslan media moved hosts, update "
             f"MEDIA_BASE_URL here and AUSLAN_MEDIA_BASE_URL in the app."
         )
-    return url[len(MEDIA_BASE_URL):]
+    return url[len(MEDIA_BASE_URL) :]
+
+
+# The fallback media host: a Cloudflare R2 bucket (auslan-mirror) that
+# sync_media_to_r2.py keeps populated. The app lists it after MEDIA_BASE_URL in
+# mediaBaseUrls (AUSLAN_MEDIA_MIRROR_BASE_URL in lib/main.dart), so keys are the
+# same strip_media_base() paths.
+MIRROR_BASE_URL = "https://cdn.auslandictionary.org"
+
+# Identify ourselves to the hosts we hit. Scripts that make many requests
+# should use make_session() so they also get connection reuse.
+USER_AGENT = (
+    "auslan-dictionary-scripts/1.0 (+https://github.com/banool/auslan_dictionary)"
+)
+
+
+def make_session() -> requests.Session:
+    """A requests Session with our User-Agent set."""
+    session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
+    return session
+
 
 # Default timeout for HTTP requests.
 DEFAULT_TIMEOUT = 180
@@ -55,72 +77,32 @@ def _rate_limit():
     _last_request_time = time.time()
 
 
-@retry(
-    exceptions=(requests.exceptions.RequestException, RuntimeError),
-    delay=1,
-    backoff=2,
-    max_delay=120,
-    tries=10,
-    logger=LOG,
-)
-def _check_video_url_request(url: str, timeout: int) -> int:
+# Cap on how long we'll honor a server's Retry-After header (seconds), so a
+# pathological value can't stall a worker indefinitely.
+RETRY_AFTER_CAP = 120
+
+
+def _respect_retry_after(response):
     """
-    Make a GET request with Range header to check if a video URL exists.
-    Only requests the first byte to minimize bandwidth.
-    Returns the status code. Retries on network errors and unexpected status codes.
-    200/206 = exists, 404 = doesn't exist. Other codes trigger a retry.
+    If the server sent a Retry-After header (typically with a 429 or 503),
+    sleep for the requested duration (capped) so we back off politely. Supports
+    both the integer-seconds and HTTP-date forms of the header.
     """
-    LOG.debug(f"Checking video URL with Range GET: {url}")
-    _rate_limit()
-    headers = {"Range": "bytes=0-0"}
-    response = requests.get(url, headers=headers, timeout=timeout)
-    status_code = response.status_code
-    # 200/206 = exists (206 is partial content for range request).
-    # 404 = doesn't exist. Both are valid final states.
-    # Any other status code should trigger a retry.
-    if status_code not in (200, 206, 404):
-        raise RuntimeError(f"Got unexpected status code {status_code} for {url}")
-    return status_code
-
-
-def check_video_url_exists(url: str, timeout: int = 30) -> bool:
-    """
-    Check if a video URL is valid by making a GET request with Range header.
-    Returns True if the URL returns 200/206, False if 404.
-    Retries with exponential backoff on network errors or unexpected status codes.
-    Raises an exception if retries are exhausted for non-404 errors.
-    """
-    status_code = _check_video_url_request(url, timeout)
-    if status_code in (200, 206):
-        return True
-    else:
-        # Must be 404 since _check_video_url_request only returns 200, 206, or 404.
-        LOG.warning(f"Video URL returned 404, skipping: {url}")
-        return False
-
-
-async def validate_video_urls(executor, urls: List[str]) -> List[str]:
-    """
-    Validate a list of video URLs using OPTIONS requests.
-    Returns only the URLs that return 200.
-    URLs that return 404 are considered invalid and skipped.
-    Other errors will raise an exception after retries are exhausted.
-    """
-    if not urls:
-        return []
-
-    loop = asyncio.get_running_loop()
-    futures = [loop.run_in_executor(executor, check_video_url_exists, url) for url in urls]
-    results = await asyncio.gather(*futures, return_exceptions=True)
-
-    valid_urls = []
-    for url, result in zip(urls, results):
-        if isinstance(result, Exception):
-            raise RuntimeError(f"Failed to validate video URL {url} after retries: {result}") from result
-        if result:
-            valid_urls.append(url)
-
-    return valid_urls
+    header = response.headers.get("Retry-After")
+    if not header:
+        return
+    delay = None
+    try:
+        delay = float(header)
+    except ValueError:
+        try:
+            delay = parsedate_to_datetime(header).timestamp() - time.time()
+        except (TypeError, ValueError):
+            delay = None
+    if delay and delay > 0:
+        delay = min(delay, RETRY_AFTER_CAP)
+        LOG.warning(f"Server asked us to back off; sleeping {delay:.0f}s (Retry-After)")
+        time.sleep(delay)
 
 
 @retry(
@@ -152,7 +134,9 @@ def load_url(url: str, timeout: int = DEFAULT_TIMEOUT) -> requests.Response:
     return response
 
 
-def load_url_safe(url: str, timeout: int = DEFAULT_TIMEOUT) -> Optional[requests.Response]:
+def load_url_safe(
+    url: str, timeout: int = DEFAULT_TIMEOUT
+) -> Optional[requests.Response]:
     """
     Load a URL, returning None instead of raising on failure.
     Useful when you want to continue processing even if some URLs fail.
@@ -198,7 +182,9 @@ async def get_pages_html(
                 LOG.warning(f"Failed to get page {url}: {result}")
                 failed.append(url)
             else:
-                raise RuntimeError(f"Failed to fetch {url} after retries: {result}") from result
+                raise RuntimeError(
+                    f"Failed to fetch {url} after retries: {result}"
+                ) from result
         elif result is None:
             # load_url_safe returned None.
             failed.append(url)
@@ -247,7 +233,9 @@ async def get_pages_html_with_urls(
             if continue_on_error:
                 LOG.warning(f"Failed to get page {url}: {result}")
             else:
-                raise RuntimeError(f"Failed to fetch {url} after retries: {result}") from result
+                raise RuntimeError(
+                    f"Failed to fetch {url} after retries: {result}"
+                ) from result
         elif result is None:
             LOG.warning(f"Failed to get page {url}")
         else:

--- a/scripts/filter_dead_media.py
+++ b/scripts/filter_dead_media.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+
+"""
+Remove videos that no longer exist on the media host from a scraped data file.
+
+Some Signbank pages list <source> tags for videos whose objects are gone from
+the media host (Nectar Swift, MEDIA_BASE_URL in common.py). Left in the data,
+tapping such a sign gives the user a spinner and then an error. This script
+takes a v1-shaped data file ({"data": [...]} with full video URLs), checks
+every unique video URL against the media host, removes the ones that are
+definitively dead (pruning sub_entries/entries this leaves empty), and writes
+the cleaned file. scrape.sh runs it as the final phase of every scrape so dead
+videos never reach assets/data; it can also be run standalone against any
+v1-shaped file, e.g. the committed assets/data/data.json.
+
+A URL is only removed on overwhelming evidence: --dead-attempts separate
+requests, spread across rounds --recheck-delay seconds apart, must ALL return
+an authentic Swift 404 — right status, Swift's transaction headers present,
+and the exact not-found body — with not a single live answer in between. A
+200/206 at any point keeps the video. Anything else (timeout, rate limiting,
+5xx, redirects, 404s that don't match the Swift fingerprint) resolves nothing:
+the URL gets extra rounds, and if it still hasn't produced a definitive answer
+after --max-rounds the whole run FAILS rather than guess (exit 3, output not
+written). Same philosophy as the scrape itself: a page that won't load fails
+the letter; nothing is ever silently dropped OR silently kept on a flaky day.
+This is also what keeps the weekly data PRs from flapping: a flaky week
+produces a red run and no PR, not churn.
+
+Expect the dead list to be stable week to week: Signbank keeps listing the
+same dead videos, so every scrape re-collects them and this script re-removes
+them (the workflow's diff-gate then sees no net change). A video Signbank
+re-uploads answers alive and returns to the data automatically.
+
+Every removal decision is recorded with full per-attempt evidence (status,
+headers, body) in <report-dir>/report.json, and verify_removed_media.py
+independently double-checks the removals in CI before a data PR opens.
+
+Usage:
+
+    # What scrape.sh runs (cleans the scrape output in place).
+    uv run python filter_dead_media.py --input all_letters.json --output all_letters.json
+
+    # Standalone against the committed data, extra-patient re-checks.
+    uv run python filter_dead_media.py --input ../assets/data/data.json \\
+        --output all_letters.json --recheck-delay 300
+
+Exit codes:
+
+    0  cleaned output written
+    1  unexpected error
+    2  too many dead URLs (--max-dead-fraction); output NOT written. Protects
+       against a host-side event that 404s everything (e.g. a container
+       rename) gutting the dictionary.
+    3  some URLs never resolved to alive-or-dead; output NOT written.
+"""
+
+import argparse
+import datetime
+import hashlib
+import json
+import logging
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from threading import Lock
+
+import requests
+
+from common import (
+    LOG,
+    _rate_limit,
+    _respect_retry_after,
+    make_session,
+    strip_media_base,
+)
+
+# The exact body Swift serves for a missing object. Part of the authentic-404
+# fingerprint: a 404 whose body differs is treated as inconclusive, not dead.
+SWIFT_404_BODY = (
+    b"<html><h1>Not Found</h1><p>The resource could not be found.</p></html>"
+)
+
+# Per-attempt classifications.
+ALIVE = "alive"
+AUTHENTIC_404 = "authentic_404"
+INCONCLUSIVE = "inconclusive"
+
+# Response headers worth keeping as evidence. x-trans-id/x-openstack-request-id
+# prove the answer came from Swift itself rather than an intermediary.
+REPORT_HEADERS = (
+    "x-trans-id",
+    "x-openstack-request-id",
+    "content-type",
+    "content-length",
+    "content-range",
+    "etag",
+    "server",
+    "date",
+    "retry-after",
+)
+
+# How much of a response body we read for fingerprinting. The Swift 404 body is
+# 70 bytes; anything bigger than this cap can't match it anyway.
+BODY_CAP = 4096
+
+REPORT_NAME = "report.json"
+
+
+def utc_now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
+
+
+def collect_url_refs(data) -> tuple:
+    """All video URLs in a v1-shaped dict: (sorted unique URLs, total ref count)."""
+    urls = set()
+    refs = 0
+    for entry in data["data"]:
+        for sub_entry in entry.get("sub_entries", []):
+            for url in sub_entry.get("video_links", []):
+                urls.add(url)
+                refs += 1
+    return sorted(urls), refs
+
+
+def classify_response(response, body: bytes) -> str:
+    """Classify one response as ALIVE, AUTHENTIC_404, or INCONCLUSIVE.
+
+    Alive needs no body check: an intermediary faking a 200 misclassifies
+    toward KEEPING a video, which is the safe direction. Dead requires the full
+    Swift fingerprint; any deviation degrades to inconclusive (also safe)."""
+    status = response.status_code
+    if status in (200, 206):
+        return ALIVE
+    if (
+        status == 404
+        and response.headers.get("x-trans-id")
+        and response.headers.get("x-openstack-request-id")
+        and response.headers.get("content-type", "").startswith("text/html")
+        and body == SWIFT_404_BODY
+    ):
+        return AUTHENTIC_404
+    return INCONCLUSIVE
+
+
+def probe(session, url: str, timeout: int, round_num: int) -> dict:
+    """One Range GET against [url], returning a full evidence record."""
+    _rate_limit()
+    record = {
+        "ts": utc_now_iso(),
+        "round": round_num,
+        "status": None,
+        "classification": INCONCLUSIVE,
+        "headers": {},
+        "body_sha256": None,
+        "body_snippet": None,
+        "body_matches_swift_404": False,
+        "elapsed_ms": None,
+        "error": None,
+    }
+    started = time.time()
+    try:
+        # stream=True so a host that ignores the Range header can't make us
+        # download a whole video; we only read the body on non-2xx answers.
+        with session.get(
+            url,
+            headers={"Range": "bytes=0-0"},
+            timeout=timeout,
+            allow_redirects=False,
+            stream=True,
+        ) as response:
+            record["status"] = response.status_code
+            record["headers"] = {
+                name: response.headers[name]
+                for name in REPORT_HEADERS
+                if name in response.headers
+            }
+            body = b""
+            if response.status_code not in (200, 206):
+                for chunk in response.iter_content(256):
+                    body += chunk
+                    if len(body) > BODY_CAP:
+                        break
+                record["body_sha256"] = hashlib.sha256(body).hexdigest()
+                record["body_snippet"] = repr(body[:200])
+                record["body_matches_swift_404"] = body == SWIFT_404_BODY
+            record["classification"] = classify_response(response, body)
+            if response.status_code in (429, 503):
+                _respect_retry_after(response)
+    except requests.exceptions.RequestException as e:
+        record["error"] = str(e)
+    record["elapsed_ms"] = int((time.time() - started) * 1000)
+    return record
+
+
+def check_urls(session, urls: list, args) -> dict:
+    """Resolve every URL to alive or dead, or leave it unresolved.
+
+    Returns url -> {"result": "alive"|"dead"|None, "attempts": [...],
+    "authentic_404s": int}. Round 0 probes everything; later rounds sleep
+    --recheck-delay then re-probe only the still-undecided URLs."""
+    results = {
+        url: {"result": None, "attempts": [], "authentic_404s": 0} for url in urls
+    }
+    undecided = set(urls)
+    for round_num in range(args.max_rounds):
+        if not undecided:
+            break
+        if round_num > 0:
+            LOG.info(
+                f"Round {round_num}: {len(undecided)} URLs undecided; sleeping "
+                f"{args.recheck_delay}s before re-probing"
+            )
+            time.sleep(args.recheck_delay)
+        done = 0
+        lock = Lock()
+        total = len(undecided)
+        with ThreadPoolExecutor(max_workers=args.num_workers) as executor:
+            futures = {
+                executor.submit(probe, session, url, args.timeout, round_num): url
+                for url in sorted(undecided)
+            }
+            for future in as_completed(futures):
+                url = futures[future]
+                record = future.result()
+                state = results[url]
+                state["attempts"].append(record)
+                if record["classification"] == ALIVE:
+                    state["result"] = "alive"
+                elif record["classification"] == AUTHENTIC_404:
+                    state["authentic_404s"] += 1
+                    if state["authentic_404s"] >= args.dead_attempts:
+                        state["result"] = "dead"
+                with lock:
+                    done += 1
+                    if done % 100 == 0 or done == total:
+                        LOG.info(f"Round {round_num} progress: {done}/{total}")
+        undecided = {url for url in undecided if results[url]["result"] is None}
+    return results
+
+
+def prune_dead_urls(data, dead_urls: set) -> dict:
+    """Remove [dead_urls] from every video_links list, dropping sub_entries and
+    entries this leaves empty. Only prunes what the removal emptied: anything
+    already empty on the way in passes through untouched, so the script's
+    footprint is exactly the dead URLs and their consequences."""
+    refs_removed = 0
+    sub_entries_removed = []
+    entries_removed = []
+    affected_entries = {}  # dead url -> [entry_in_english, ...]
+    kept_entries = []
+    for entry in data["data"]:
+        word = entry["entry_in_english"]
+        had_sub_entries = bool(entry.get("sub_entries"))
+        kept_sub_entries = []
+        for index, sub_entry in enumerate(entry.get("sub_entries", [])):
+            links = sub_entry.get("video_links", [])
+            kept_links = [url for url in links if url not in dead_urls]
+            if len(kept_links) < len(links):
+                refs_removed += len(links) - len(kept_links)
+                for url in links:
+                    if url in dead_urls:
+                        words = affected_entries.setdefault(url, [])
+                        if word not in words:
+                            words.append(word)
+                sub_entry["video_links"] = kept_links
+                if not kept_links:
+                    sub_entries_removed.append({"word": word, "index": index})
+                    continue
+            kept_sub_entries.append(sub_entry)
+        entry["sub_entries"] = kept_sub_entries
+        if had_sub_entries and not kept_sub_entries:
+            entries_removed.append(word)
+            continue
+        kept_entries.append(entry)
+    data["data"] = kept_entries
+    return {
+        "refs_removed": refs_removed,
+        "sub_entries_removed": sub_entries_removed,
+        "entries_removed": entries_removed,
+        "affected_entries": affected_entries,
+    }
+
+
+def write_json_atomic(path: Path, obj):
+    """Write JSON via a temp file + rename so an interrupted run never leaves a
+    complete-looking partial behind. Matches scrape_signbank.py's format
+    (indent=2, no trailing newline) so outputs are byte-comparable."""
+    tmp_path = path.with_name(path.name + ".part")
+    with open(tmp_path, "w") as f:
+        f.write(json.dumps(obj, indent=2))
+    os.replace(tmp_path, path)
+
+
+def evidence_for(url: str, state: dict, affected_entries: dict) -> dict:
+    return {
+        "url": url,
+        "path": strip_media_base(url),
+        "affected_entries": affected_entries.get(url, []),
+        "attempts": state["attempts"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Where to write the cleaned data. May equal --input.",
+    )
+    parser.add_argument(
+        "--report-dir",
+        type=Path,
+        default=Path("media_filter_report"),
+        help="Directory for report.json (default: media_filter_report).",
+    )
+    parser.add_argument("--num-workers", type=int, default=8)
+    parser.add_argument(
+        "--timeout", type=int, default=30, help="Per-request timeout in seconds."
+    )
+    parser.add_argument(
+        "--recheck-delay",
+        type=int,
+        default=60,
+        help="Seconds between re-check rounds (default: 60).",
+    )
+    parser.add_argument(
+        "--dead-attempts",
+        type=int,
+        default=5,
+        help="Authentic 404s required, across that many rounds, to call a URL "
+        "dead (default: 5).",
+    )
+    parser.add_argument(
+        "--max-rounds",
+        type=int,
+        default=8,
+        help="Give up (exit 3) if a URL is still unresolved after this many "
+        "rounds (default: 8).",
+    )
+    parser.add_argument(
+        "--max-dead-fraction",
+        type=float,
+        default=0.05,
+        help="Fail (exit 2) without writing output if more than this fraction "
+        "of unique URLs is dead (default: 0.05).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Only check the first N unique URLs (for testing).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Classify and report, but never write --output.",
+    )
+    parser.add_argument("-d", "--debug", action="store_true")
+    args = parser.parse_args()
+
+    LOG.setLevel(logging.DEBUG if args.debug else logging.INFO)
+
+    if args.dead_attempts > args.max_rounds:
+        parser.error("--dead-attempts cannot exceed --max-rounds")
+    if not args.input.exists():
+        parser.error(f"Input file not found: {args.input}")
+
+    started_at = utc_now_iso()
+    with open(args.input) as f:
+        data = json.load(f)
+
+    urls, total_refs = collect_url_refs(data)
+    # Every URL must be under the media base (the scrape guarantees this);
+    # raises otherwise, same as make_data_v2.py would.
+    for url in urls:
+        strip_media_base(url)
+    LOG.info(f"{len(urls)} unique video URLs ({total_refs} references) in {args.input}")
+    if args.limit is not None:
+        urls = urls[: args.limit]
+        LOG.info(f"Limiting to first {len(urls)} URLs")
+
+    session = make_session()
+    results = check_urls(session, urls, args)
+
+    alive_first_try = []
+    alive_after_retry = []
+    dead = []
+    unresolved = []
+    for url in urls:
+        state = results[url]
+        if state["result"] == "alive":
+            if len(state["attempts"]) == 1:
+                alive_first_try.append(url)
+            else:
+                alive_after_retry.append(url)
+                if state["authentic_404s"] > 0:
+                    LOG.warning(
+                        f"Transient 404 recovered (host flakiness), keeping: {url}"
+                    )
+        elif state["result"] == "dead":
+            dead.append(url)
+            LOG.warning(f"Dead ({state['authentic_404s']} authentic 404s): {url}")
+        else:
+            unresolved.append(url)
+            LOG.error(f"Unresolved after {len(state['attempts'])} attempts: {url}")
+
+    dead_fraction = len(dead) / len(urls) if urls else 0.0
+    prune_stats = prune_dead_urls(data, set(dead))
+
+    report = {
+        "schema_version": 1,
+        "started_at": started_at,
+        "finished_at": utc_now_iso(),
+        "input": str(args.input),
+        "output": str(args.output),
+        "params": {
+            key: (str(value) if isinstance(value, Path) else value)
+            for key, value in vars(args).items()
+        },
+        "counts": {
+            "unique_urls": len(urls),
+            "total_refs": total_refs,
+            "alive_first_try": len(alive_first_try),
+            "alive_after_retry": len(alive_after_retry),
+            "dead": len(dead),
+            "unresolved": len(unresolved),
+            "dead_fraction": round(dead_fraction, 4),
+            "refs_removed": prune_stats["refs_removed"],
+            "sub_entries_removed": len(prune_stats["sub_entries_removed"]),
+            "entries_removed": len(prune_stats["entries_removed"]),
+        },
+        "dead": [
+            evidence_for(url, results[url], prune_stats["affected_entries"])
+            for url in dead
+        ],
+        "unresolved": [
+            evidence_for(url, results[url], prune_stats["affected_entries"])
+            for url in unresolved
+        ],
+        "alive_after_retry": [
+            evidence_for(url, results[url], prune_stats["affected_entries"])
+            for url in alive_after_retry
+        ],
+        "sub_entries_removed": prune_stats["sub_entries_removed"],
+        "entries_removed": prune_stats["entries_removed"],
+    }
+    args.report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = args.report_dir / REPORT_NAME
+    write_json_atomic(report_path, report)
+    LOG.info(f"Report written to {report_path}")
+
+    LOG.info(
+        "Checked %d URLs: alive=%d (%d only after retries) dead=%d unresolved=%d; "
+        "pruned %d refs, %d sub_entries, %d entries"
+        % (
+            len(urls),
+            len(alive_first_try) + len(alive_after_retry),
+            len(alive_after_retry),
+            len(dead),
+            len(unresolved),
+            prune_stats["refs_removed"],
+            len(prune_stats["sub_entries_removed"]),
+            len(prune_stats["entries_removed"]),
+        )
+    )
+
+    if unresolved:
+        LOG.error(
+            f"{len(unresolved)} URLs never resolved to alive-or-dead after "
+            f"{args.max_rounds} rounds; refusing to write output. See {report_path}."
+        )
+        return 3
+    if dead_fraction > args.max_dead_fraction:
+        LOG.error(
+            f"{len(dead)}/{len(urls)} URLs dead ({dead_fraction:.1%}) exceeds "
+            f"--max-dead-fraction {args.max_dead_fraction:.1%}; this looks like a "
+            f"host-side event, refusing to write output. See {report_path}."
+        )
+        return 2
+    if args.dry_run:
+        LOG.info("Dry run: not writing output.")
+        return 0
+
+    write_json_atomic(args.output, data)
+    LOG.info(f"Cleaned data written to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/incremental_scrape.sh
+++ b/scripts/incremental_scrape.sh
@@ -6,7 +6,6 @@
 #   ./incremental_scrape.sh              # Start fresh or resume from last checkpoint
 #   ./incremental_scrape.sh --fresh      # Force a fresh start (ignore any existing progress)
 #   ./incremental_scrape.sh --from d     # Start/resume from letter 'd'
-#   ./incremental_scrape.sh --validate   # Also validate video URLs with OPTIONS requests
 #
 # The script automatically saves progress after each letter, so if it crashes
 # or you need to stop it, you can just run it again to resume.
@@ -23,7 +22,6 @@ cd "$(dirname "$0")"
 # Parse arguments.
 FRESH=false
 START_FROM=""
-VALIDATE_FLAG=""
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -35,13 +33,9 @@ while [[ $# -gt 0 ]]; do
             START_FROM="$2"
             shift 2
             ;;
-        --validate)
-            VALIDATE_FLAG="--validate-video-urls"
-            shift
-            ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--fresh] [--from LETTER] [--validate]"
+            echo "Usage: $0 [--fresh] [--from LETTER]"
             exit 1
             ;;
     esac
@@ -103,8 +97,7 @@ for l in {a..z}; do
             --output-file "next_${l}.json" \
             --existing-file "$PROGRESS_FILE" \
             --letters "$l" \
-            --categories-file ../assets/data/categories.json \
-            $VALIDATE_FLAG; then
+            --categories-file ../assets/data/categories.json; then
 
             # Success - update progress file and state.
             mv "next_${l}.json" "$PROGRESS_FILE"

--- a/scripts/scrape.sh
+++ b/scripts/scrape.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Scrapes the signbank for category data first and then for entry data.
+# Scrapes the signbank for category data, then entry data, then filters out
+# videos that 404 on the media host so they never ship (filter_dead_media.py).
 # This is the main entry point for a full scrape.
 #
 # Usage:
 #   ./scrape.sh              # Normal scrape
-#   ./scrape.sh --validate   # Also validate video URLs
 #   ./scrape.sh --fresh      # Force fresh start (ignore existing progress)
 
 set -e
@@ -37,6 +37,17 @@ sleep 10
 echo ""
 echo "Step 2: Scraping entries..."
 ./incremental_scrape.sh $ARGS
+
+# Step 3: Remove videos that 404 on the media host. The prefilter snapshot is
+# taken here (not by the filter) so verify_removed_media.py's "before" input is
+# something the filter never touched.
+echo ""
+echo "Step 3: Filtering dead media..."
+cp all_letters.json all_letters_prefilter.json
+python filter_dead_media.py \
+    --input all_letters.json \
+    --output all_letters.json \
+    --report-dir media_filter_report
 
 echo ""
 echo "========================================"

--- a/scripts/scrape_signbank.py
+++ b/scripts/scrape_signbank.py
@@ -40,7 +40,7 @@ from typing import Dict, List
 
 from bs4 import BeautifulSoup
 
-from common import LOG, get_pages_html, strip_media_base, validate_video_urls
+from common import LOG, get_pages_html, strip_media_base
 
 SITE_ROOT = "http://www.auslan.org.au"
 LETTER_PAGE_TEMPLATE = SITE_ROOT + "/dictionary/search/?query={letter}&page={page}"
@@ -319,11 +319,6 @@ def parse_args():
     output_args.add_argument("--stdout", action="store_true")
     parser.add_argument("--existing-file", help="Start with this file as the base")
     parser.add_argument("--num-workers", type=int, default=8)
-    parser.add_argument(
-        "--validate-video-urls",
-        action="store_true",
-        help="Check each video URL with an OPTIONS request and skip videos that don't return 200",
-    )
     return parser.parse_args()
 
 
@@ -390,62 +385,6 @@ async def main():
     for word, info in word_to_info.items():
         categories = word_to_categories.get(word, [])
         info["categories"] = categories
-
-    # Validate video URLs if requested.
-    if args.validate_video_urls:
-        LOG.info("Validating video URLs with OPTIONS requests...")
-        # Collect all video URLs.
-        all_video_urls = set()
-        for info in word_to_info.values():
-            for sub_entry in info["sub_entries"]:
-                all_video_urls.update(sub_entry["video_links"])
-
-        LOG.info(f"Found {len(all_video_urls)} unique video URLs to validate")
-
-        # Validate them in batch.
-        valid_urls = set(await validate_video_urls(executor, list(all_video_urls)))
-        invalid_count = len(all_video_urls) - len(valid_urls)
-        LOG.info(f"Validated video URLs: {len(valid_urls)} valid, {invalid_count} invalid")
-
-        # Filter out invalid URLs from all sub_entries.
-        for info in word_to_info.values():
-            for sub_entry in info["sub_entries"]:
-                original_count = len(sub_entry["video_links"])
-                sub_entry["video_links"] = [
-                    url for url in sub_entry["video_links"] if url in valid_urls
-                ]
-                if len(sub_entry["video_links"]) < original_count:
-                    LOG.debug(
-                        f"Removed {original_count - len(sub_entry['video_links'])} "
-                        f"invalid video URLs from entry"
-                    )
-
-        # Remove sub_entries with no valid video links.
-        removed_sub_entries = 0
-        for word, info in word_to_info.items():
-            original_count = len(info["sub_entries"])
-            info["sub_entries"] = [
-                se for se in info["sub_entries"] if se["video_links"]
-            ]
-            removed = original_count - len(info["sub_entries"])
-            if removed > 0:
-                LOG.warning(
-                    f"Removed {removed} sub_entries with no valid videos from '{word}'"
-                )
-                removed_sub_entries += removed
-
-        # Remove entries with no valid sub_entries.
-        entries_to_remove = [
-            word for word, info in word_to_info.items() if not info["sub_entries"]
-        ]
-        for word in entries_to_remove:
-            LOG.warning(f"Removing entry '{word}' - no valid sub_entries remaining")
-            del word_to_info[word]
-
-        LOG.info(
-            f"Validation complete: removed {removed_sub_entries} sub_entries and "
-            f"{len(entries_to_remove)} entries with no valid videos"
-        )
 
     # Fail loudly if any video is served from an unexpected base. The app
     # ships AUSLAN_MEDIA_BASE_URL and stores only the path after it (see

--- a/scripts/verify_removed_media.py
+++ b/scripts/verify_removed_media.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+
+"""
+Independently confirm that every video URL the media filter removed really is
+gone from the media host.
+
+This is a deliberate second implementation, not a refactor target: it must
+stay a different code path from filter_dead_media.py so that a bug in the
+filter's classifier can't agree with itself. The differences are on purpose:
+stdlib urllib instead of requests (none of common.py's HTTP machinery), plain
+full GETs with no Range header, sequential requests at ~1s + jitter instead of
+a threaded sweep, a different User-Agent, and a locally re-implemented
+authentic-404 fingerprint.
+
+It computes the removed set itself by diffing --before and --after (never
+trusting the filter's report), then re-checks every removed URL against the
+media host over --attempts rounds spaced --attempt-delay apart:
+
+    FALSE_POSITIVE  answered alive at any point -> the filter removed a
+                    working video; FAIL.
+    CONFIRMED       every attempt was an authentic Swift 404.
+    UNCONFIRMED     anything else -> the removal can't be verified; FAIL.
+
+It also fails if the filter ADDED any URL, and samples kept URLs, warning
+(without failing — keeping too much is the safe direction) if any look dead.
+The mirror (MIRROR_BASE_URL) status of each removed URL is recorded for
+information only: a Nectar-dead video may legitimately still sit in the mirror
+bucket until archive_orphaned_media.py moves it aside.
+
+Usage:
+
+    uv run python verify_removed_media.py \\
+        --before all_letters_prefilter.json --after all_letters.json
+
+Exit codes: 0 all removals confirmed; 1 verification failed or error.
+"""
+
+import argparse
+import json
+import logging
+import os
+import random
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+from common import LOG, MIRROR_BASE_URL, strip_media_base
+
+VERIFY_USER_AGENT = "auslan-dictionary-verify/1.0"
+
+# Swift's exact body for a missing object. Re-implemented here rather than
+# imported from filter_dead_media on purpose (see module docstring).
+NOT_FOUND_BODY = (
+    b"<html><h1>Not Found</h1><p>The resource could not be found.</p></html>"
+)
+
+# How much body we read: enough to prove a video serves bytes / to hold the
+# 70-byte not-found body, without downloading whole videos.
+READ_CAP = 1024
+
+VERDICT_CONFIRMED = "CONFIRMED"
+VERDICT_FALSE_POSITIVE = "FALSE_POSITIVE"
+VERDICT_UNCONFIRMED = "UNCONFIRMED"
+
+
+def collect_urls(path: Path) -> set:
+    """Every video URL in a v1-shaped data file."""
+    with open(path) as f:
+        data = json.load(f)
+    urls = set()
+    for entry in data["data"]:
+        for sub_entry in entry.get("sub_entries", []):
+            urls.update(sub_entry.get("video_links", []))
+    return urls
+
+
+def pace():
+    """Sequential, deliberately un-burst-y pacing (vs the filter's threaded
+    0.1s-interval sweep)."""
+    time.sleep(0.5 + random.random())
+
+
+def fetch(url: str, timeout: int) -> dict:
+    """One plain GET. Returns {status, headers (HTTPMessage or None), body,
+    error}; 4xx/5xx come back as records, not exceptions."""
+    request = urllib.request.Request(url, headers={"User-Agent": VERIFY_USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return {
+                "status": response.status,
+                "headers": response.headers,
+                "body": response.read(READ_CAP),
+                "error": None,
+            }
+    except urllib.error.HTTPError as e:
+        try:
+            body = e.read(READ_CAP)
+        except Exception:
+            body = b""
+        return {"status": e.code, "headers": e.headers, "body": body, "error": None}
+    except Exception as e:
+        return {"status": None, "headers": None, "body": b"", "error": str(e)}
+
+
+def is_alive(result: dict) -> bool:
+    return result["status"] == 200 and len(result["body"]) > 0
+
+
+def is_authentic_404(result: dict) -> bool:
+    headers = result["headers"]
+    return (
+        result["status"] == 404
+        and headers is not None
+        and headers.get("x-trans-id") is not None
+        and headers.get("x-openstack-request-id") is not None
+        and (headers.get("content-type") or "").startswith("text/html")
+        and result["body"].strip() == NOT_FOUND_BODY
+    )
+
+
+def attempt_record(result: dict, attempt: int) -> dict:
+    """A JSON-serializable evidence record for one fetch."""
+    headers = result["headers"]
+    kept_headers = {}
+    if headers is not None:
+        for name in (
+            "x-trans-id",
+            "x-openstack-request-id",
+            "content-type",
+            "content-length",
+            "server",
+            "date",
+            "cf-cache-status",
+        ):
+            if headers.get(name) is not None:
+                kept_headers[name] = headers.get(name)
+    return {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "attempt": attempt,
+        "status": result["status"],
+        "headers": kept_headers,
+        "body_snippet": repr(result["body"][:200]),
+        "alive": is_alive(result),
+        "authentic_404": is_authentic_404(result),
+        "error": result["error"],
+    }
+
+
+def write_json_atomic(path: Path, obj):
+    tmp_path = path.with_name(path.name + ".part")
+    with open(tmp_path, "w") as f:
+        f.write(json.dumps(obj, indent=2))
+    os.replace(tmp_path, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--before", required=True, type=Path)
+    parser.add_argument("--after", required=True, type=Path)
+    parser.add_argument(
+        "--report-file",
+        type=Path,
+        default=Path("media_filter_report/verify_report.json"),
+    )
+    parser.add_argument(
+        "--attempts",
+        type=int,
+        default=3,
+        help="Rounds of checks per removed URL (default: 3).",
+    )
+    parser.add_argument(
+        "--attempt-delay",
+        type=int,
+        default=30,
+        help="Seconds between rounds (default: 30).",
+    )
+    parser.add_argument(
+        "--initial-delay",
+        type=int,
+        default=0,
+        help="Sleep this long before the first check, so probes land at a "
+        "different time than the filter's (CI passes 120).",
+    )
+    parser.add_argument(
+        "--kept-sample-size",
+        type=int,
+        default=30,
+        help="How many kept URLs to spot-check as alive (default: 30).",
+    )
+    parser.add_argument("--timeout", type=int, default=60)
+    parser.add_argument("-d", "--debug", action="store_true")
+    args = parser.parse_args()
+
+    LOG.setLevel(logging.DEBUG if args.debug else logging.INFO)
+
+    for path in (args.before, args.after):
+        if not path.exists():
+            parser.error(f"File not found: {path}")
+
+    before = collect_urls(args.before)
+    after = collect_urls(args.after)
+    removed = sorted(before - after)
+    added = sorted(after - before)
+    LOG.info(
+        f"{len(before)} unique URLs before, {len(after)} after: "
+        f"{len(removed)} removed, {len(added)} added"
+    )
+    if added:
+        LOG.error(
+            f"The filter must never ADD URLs, but {len(added)} appeared: "
+            f"{added[:5]}{'...' if len(added) > 5 else ''}"
+        )
+
+    if args.initial_delay and removed:
+        LOG.info(f"Sleeping {args.initial_delay}s before checking (--initial-delay)")
+        time.sleep(args.initial_delay)
+
+    # Re-check every removed URL over --attempts spaced rounds. A URL that ever
+    # answers alive is decided immediately (false positive); everything else
+    # gets all attempts so CONFIRMED means "authentic 404 every single time".
+    evidence = {url: [] for url in removed}
+    false_positives = []
+    undecided = list(removed)
+    for attempt in range(args.attempts):
+        if attempt > 0 and undecided:
+            LOG.info(f"Sleeping {args.attempt_delay}s before round {attempt}")
+            time.sleep(args.attempt_delay)
+        still_undecided = []
+        for url in undecided:
+            pace()
+            result = fetch(url, args.timeout)
+            evidence[url].append(attempt_record(result, attempt))
+            if is_alive(result):
+                LOG.error(f"FALSE POSITIVE: removed URL answered alive: {url}")
+                false_positives.append(url)
+            else:
+                still_undecided.append(url)
+        undecided = still_undecided
+
+    confirmed = []
+    unconfirmed = []
+    for url in removed:
+        if url in false_positives:
+            continue
+        records = evidence[url]
+        if len(records) == args.attempts and all(r["authentic_404"] for r in records):
+            confirmed.append(url)
+        else:
+            unconfirmed.append(url)
+            LOG.error(f"UNCONFIRMED: could not verify removal of {url}")
+
+    # Informational: does the mirror still hold a copy? (Expected for videos
+    # that died on Nectar after being mirrored; the archiver deals with them.)
+    mirror_status = {}
+    for url in removed:
+        pace()
+        result = fetch(MIRROR_BASE_URL + strip_media_base(url), args.timeout)
+        if is_alive(result):
+            mirror_status[url] = "alive"
+        elif result["status"] == 404:
+            mirror_status[url] = "404"
+        else:
+            mirror_status[url] = f"other ({result['status'] or result['error']})"
+    mirror_alive = sorted(u for u, s in mirror_status.items() if s == "alive")
+    if mirror_alive:
+        LOG.info(
+            f"{len(mirror_alive)} removed URLs still alive on the mirror "
+            f"(informational; archive_orphaned_media.py handles these)"
+        )
+
+    # Spot-check kept URLs the same user-visible way (must serve bytes from the
+    # primary host). Failures warn but don't fail the run: keeping too much is
+    # the safe direction, and the filter itself refuses to guess.
+    kept_sample = sorted(
+        random.sample(sorted(after), min(args.kept_sample_size, len(after)))
+    )
+    kept_suspect = {}
+    for url in kept_sample:
+        pace()
+        result = fetch(url, args.timeout)
+        if not is_alive(result):
+            kept_suspect[url] = attempt_record(result, 0)
+            LOG.warning(
+                f"KEPT_SUSPECT: kept URL did not answer alive "
+                f"(status={result['status']} error={result['error']}): {url}"
+            )
+
+    report = {
+        "schema_version": 1,
+        "finished_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "params": {
+            key: (str(value) if isinstance(value, Path) else value)
+            for key, value in vars(args).items()
+        },
+        "removed_total": len(removed),
+        "confirmed": len(confirmed),
+        "false_positives": [
+            {"url": url, "attempts": evidence[url]} for url in false_positives
+        ],
+        "unconfirmed": [{"url": url, "attempts": evidence[url]} for url in unconfirmed],
+        "added_urls": added,
+        "mirror_status": mirror_status,
+        "kept_sampled": len(kept_sample),
+        "kept_suspect": kept_suspect,
+    }
+    args.report_file.parent.mkdir(parents=True, exist_ok=True)
+    write_json_atomic(args.report_file, report)
+    LOG.info(f"Report written to {args.report_file}")
+
+    LOG.info(
+        f"Removed {len(removed)}: confirmed={len(confirmed)} "
+        f"false_positives={len(false_positives)} unconfirmed={len(unconfirmed)}; "
+        f"kept sample {len(kept_sample)}, suspect {len(kept_suspect)}"
+    )
+    if false_positives or unconfirmed or added:
+        LOG.error("Verification FAILED.")
+        return 1
+    LOG.info("All removals independently confirmed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Signbank pages reference videos whose objects are gone from the media host; those URLs ship in the data and ~5.6% of app sessions hit a video 404 (see the self-hosted Aptabase analytics, 2026-07-17 → 2026-07-31).

## What this adds

- **`scripts/filter_dead_media.py`** — final phase of `scrape.sh`. Checks every unique video URL; removes a URL only after **5 authentic Swift 404s** (status + `x-trans-id`/`x-openstack-request-id` headers + exact not-found body) across rounds spaced `--recheck-delay` apart, with zero live answers in between. Anything that never resolves to alive-or-dead **fails the run** (no PR that week) rather than guessing — this is what keeps the weekly data PRs from flapping. A dead fraction over 5% also fails without writing output, so a host-side event can't gut the dictionary. Full per-attempt evidence goes to `media_filter_report/report.json`.
- **`scripts/verify_removed_media.py`** — independent double-check in CI before the data PR can open: deliberately different code path (stdlib urllib, full GETs, sequential pacing, own fingerprint impl), diffs pre-/post-filter files itself, fails on any removal that answers alive or can't be confirmed.
- **`scripts/archive_orphaned_media.py`** — manual housekeeping: moves R2 mirror objects no longer referenced by data-v2.json to an `archive/` prefix (server-side copy + delete; nothing hard-deleted). Analog of SLSL's `find_unused_videos` command.
- Removes the old in-scrape `--validate-video-urls` path (unused in CI, and it re-checked the whole corpus once per letter).
- Workflow: scrape step now filters implicitly; new verify + report-artifact steps run before the diff-gate.

## Tested

- Live smoke tests against known-good and known-dead URLs: correct removal/pruning with full evidence, dead-fraction gate (exit 2, no output), unresolved gate (exit 3, no output), in-place output, verify confirmed/false-positive/added-URL paths, archiver list-only run against the real bucket (0 orphans today; 29 referenced paths missing from the mirror, consistent with dead-at-source videos).

The first data cleanup (standalone filter run on the committed data + independent verify) follows as a separate data-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bum5SFYEZD4gqX8PZhT6i