### PR TITLE
Repin dictionarylib to db918324 (shared-list limit handling)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,8 +269,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: e3a083ef6aebced0b4f3d0fe386f7434381ce2b5
-      resolved-ref: e3a083ef6aebced0b4f3d0fe386f7434381ce2b5
+      ref: "0b54a928019c2201291fd4e660525749e07ab44b"
+      resolved-ref: "0b54a928019c2201291fd4e660525749e07ab44b"
       url: "https://github.com/banool/dictionarylib.git"
     source: git
     version: "0.3.110"
@@ -278,8 +278,8 @@ packages:
     dependency: "direct dev"
     description:
       path: dictionarylib_test_support
-      ref: e3a083ef6aebced0b4f3d0fe386f7434381ce2b5
-      resolved-ref: e3a083ef6aebced0b4f3d0fe386f7434381ce2b5
+      ref: "0b54a928019c2201291fd4e660525749e07ab44b"
+      resolved-ref: "0b54a928019c2201291fd4e660525749e07ab44b"
       url: "https://github.com/banool/dictionarylib.git"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,17 +269,17 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: efd2472a1a6f729683243b56b19597e27821cc66
-      resolved-ref: efd2472a1a6f729683243b56b19597e27821cc66
+      ref: db918324bae777d55c628d79aba2bb6d14bd7ebd
+      resolved-ref: db918324bae777d55c628d79aba2bb6d14bd7ebd
       url: "https://github.com/banool/dictionarylib.git"
     source: git
-    version: "0.3.106"
+    version: "0.3.107"
   dictionarylib_test_support:
     dependency: "direct dev"
     description:
       path: dictionarylib_test_support
-      ref: efd2472a1a6f729683243b56b19597e27821cc66
-      resolved-ref: efd2472a1a6f729683243b56b19597e27821cc66
+      ref: db918324bae777d55c628d79aba2bb6d14bd7ebd
+      resolved-ref: db918324bae777d55c628d79aba2bb6d14bd7ebd
       url: "https://github.com/banool/dictionarylib.git"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,17 +269,17 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: db918324bae777d55c628d79aba2bb6d14bd7ebd
-      resolved-ref: db918324bae777d55c628d79aba2bb6d14bd7ebd
+      ref: "22660286e98c4a14e462cb01056d138375bad011"
+      resolved-ref: "22660286e98c4a14e462cb01056d138375bad011"
       url: "https://github.com/banool/dictionarylib.git"
     source: git
-    version: "0.3.107"
+    version: "0.3.108"
   dictionarylib_test_support:
     dependency: "direct dev"
     description:
       path: dictionarylib_test_support
-      ref: db918324bae777d55c628d79aba2bb6d14bd7ebd
-      resolved-ref: db918324bae777d55c628d79aba2bb6d14bd7ebd
+      ref: "22660286e98c4a14e462cb01056d138375bad011"
+      resolved-ref: "22660286e98c4a14e462cb01056d138375bad011"
       url: "https://github.com/banool/dictionarylib.git"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,17 +269,17 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "22660286e98c4a14e462cb01056d138375bad011"
-      resolved-ref: "22660286e98c4a14e462cb01056d138375bad011"
+      ref: f6df5fcd6b4549e4e19620445e259dea1caf6e35
+      resolved-ref: f6df5fcd6b4549e4e19620445e259dea1caf6e35
       url: "https://github.com/banool/dictionarylib.git"
     source: git
-    version: "0.3.108"
+    version: "0.3.109"
   dictionarylib_test_support:
     dependency: "direct dev"
     description:
       path: dictionarylib_test_support
-      ref: "22660286e98c4a14e462cb01056d138375bad011"
-      resolved-ref: "22660286e98c4a14e462cb01056d138375bad011"
+      ref: f6df5fcd6b4549e4e19620445e259dea1caf6e35
+      resolved-ref: f6df5fcd6b4549e4e19620445e259dea1caf6e35
       url: "https://github.com/banool/dictionarylib.git"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,17 +269,17 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: f6df5fcd6b4549e4e19620445e259dea1caf6e35
-      resolved-ref: f6df5fcd6b4549e4e19620445e259dea1caf6e35
+      ref: e3a083ef6aebced0b4f3d0fe386f7434381ce2b5
+      resolved-ref: e3a083ef6aebced0b4f3d0fe386f7434381ce2b5
       url: "https://github.com/banool/dictionarylib.git"
     source: git
-    version: "0.3.109"
+    version: "0.3.110"
   dictionarylib_test_support:
     dependency: "direct dev"
     description:
       path: dictionarylib_test_support
-      ref: f6df5fcd6b4549e4e19620445e259dea1caf6e35
-      resolved-ref: f6df5fcd6b4549e4e19620445e259dea1caf6e35
+      ref: e3a083ef6aebced0b4f3d0fe386f7434381ce2b5
+      resolved-ref: e3a083ef6aebced0b4f3d0fe386f7434381ce2b5
       url: "https://github.com/banool/dictionarylib.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Free video dictionary of Auslan signs
 
 publish_to: 'none'
 
-version: 2.0.64+975
+version: 2.0.65+976
 
 environment:
   sdk: '>=3.2.3 <4.0.0'
@@ -22,7 +22,7 @@ dependencies:
       url: https://github.com/banool/dictionarylib.git
       # NOTE: keep this ref and dictionarylib_test_support's ref (below, in
       # dev_dependencies) on the SAME commit when repinning.
-      ref: f6df5fcd6b4549e4e19620445e259dea1caf6e35
+      ref: e3a083ef6aebced0b4f3d0fe386f7434381ce2b5
   dolphinsr: ^4.0.0
   flutter_native_splash:
   go_router:
@@ -37,7 +37,7 @@ dev_dependencies:
   dictionarylib_test_support:
     git:
       url: https://github.com/banool/dictionarylib.git
-      ref: f6df5fcd6b4549e4e19620445e259dea1caf6e35
+      ref: e3a083ef6aebced0b4f3d0fe386f7434381ce2b5
       path: dictionarylib_test_support
   dependency_validator:
   flutter_driver:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Free video dictionary of Auslan signs
 
 publish_to: 'none'
 
-version: 2.0.61+972
+version: 2.0.62+973
 
 environment:
   sdk: '>=3.2.3 <4.0.0'
@@ -22,7 +22,7 @@ dependencies:
       url: https://github.com/banool/dictionarylib.git
       # NOTE: keep this ref and dictionarylib_test_support's ref (below, in
       # dev_dependencies) on the SAME commit when repinning.
-      ref: efd2472a1a6f729683243b56b19597e27821cc66
+      ref: db918324bae777d55c628d79aba2bb6d14bd7ebd
   dolphinsr: ^4.0.0
   flutter_native_splash:
   go_router:
@@ -37,7 +37,7 @@ dev_dependencies:
   dictionarylib_test_support:
     git:
       url: https://github.com/banool/dictionarylib.git
-      ref: efd2472a1a6f729683243b56b19597e27821cc66
+      ref: db918324bae777d55c628d79aba2bb6d14bd7ebd
       path: dictionarylib_test_support
   dependency_validator:
   flutter_driver:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Free video dictionary of Auslan signs
 
 publish_to: 'none'
 
-version: 2.0.62+973
+version: 2.0.63+974
 
 environment:
   sdk: '>=3.2.3 <4.0.0'
@@ -22,7 +22,7 @@ dependencies:
       url: https://github.com/banool/dictionarylib.git
       # NOTE: keep this ref and dictionarylib_test_support's ref (below, in
       # dev_dependencies) on the SAME commit when repinning.
-      ref: db918324bae777d55c628d79aba2bb6d14bd7ebd
+      ref: 22660286e98c4a14e462cb01056d138375bad011
   dolphinsr: ^4.0.0
   flutter_native_splash:
   go_router:
@@ -37,7 +37,7 @@ dev_dependencies:
   dictionarylib_test_support:
     git:
       url: https://github.com/banool/dictionarylib.git
-      ref: db918324bae777d55c628d79aba2bb6d14bd7ebd
+      ref: 22660286e98c4a14e462cb01056d138375bad011
       path: dictionarylib_test_support
   dependency_validator:
   flutter_driver:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Free video dictionary of Auslan signs
 
 publish_to: 'none'
 
-version: 2.0.63+974
+version: 2.0.64+975
 
 environment:
   sdk: '>=3.2.3 <4.0.0'
@@ -22,7 +22,7 @@ dependencies:
       url: https://github.com/banool/dictionarylib.git
       # NOTE: keep this ref and dictionarylib_test_support's ref (below, in
       # dev_dependencies) on the SAME commit when repinning.
-      ref: 22660286e98c4a14e462cb01056d138375bad011
+      ref: f6df5fcd6b4549e4e19620445e259dea1caf6e35
   dolphinsr: ^4.0.0
   flutter_native_splash:
   go_router:
@@ -37,7 +37,7 @@ dev_dependencies:
   dictionarylib_test_support:
     git:
       url: https://github.com/banool/dictionarylib.git
-      ref: 22660286e98c4a14e462cb01056d138375bad011
+      ref: f6df5fcd6b4549e4e19620445e259dea1caf6e35
       path: dictionarylib_test_support
   dependency_validator:
   flutter_driver:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Free video dictionary of Auslan signs
 
 publish_to: 'none'
 
-version: 2.0.65+976
+version: 2.0.66+977
 
 environment:
   sdk: '>=3.2.3 <4.0.0'
@@ -22,7 +22,7 @@ dependencies:
       url: https://github.com/banool/dictionarylib.git
       # NOTE: keep this ref and dictionarylib_test_support's ref (below, in
       # dev_dependencies) on the SAME commit when repinning.
-      ref: e3a083ef6aebced0b4f3d0fe386f7434381ce2b5
+      ref: 0b54a928019c2201291fd4e660525749e07ab44b
   dolphinsr: ^4.0.0
   flutter_native_splash:
   go_router:
@@ -37,7 +37,7 @@ dev_dependencies:
   dictionarylib_test_support:
     git:
       url: https://github.com/banool/dictionarylib.git
-      ref: e3a083ef6aebced0b4f3d0fe386f7434381ce2b5
+      ref: 0b54a928019c2201291fd4e660525749e07ab44b
       path: dictionarylib_test_support
   dependency_validator:
   flutter_driver:


### PR DESCRIPTION
Repin only — no app-code changes. Neither app hardcodes the shared-list limits; it all lives in dictionarylib.

Picks up banool/dictionarylib#11, which handles the backend's new per-user list cap (100) and raised per-list entry cap (10000) from banool/dictionary_backend#2.

What that gets this app:
- Sharing a list when you already own 100 gets a real explanation instead of a generic permission error.
- Adding a word to a shared list that's already full now shows a snackbar saying the addition wasn't shared. Previously the op was rejected server-side, logged, and dropped — the word stayed in the local list looking shared when it wasn't.

## Verified

`flutter pub get`, `flutter analyze lib/` (no issues), `flutter test` (4 pass) against the repinned dictionarylib. Both `ref`s moved together, as required.

## Note on the pin

`db918324` is the tip of dictionarylib's `list-limits` branch, so this is pinned to an unmerged commit — deliberate, so the whole stack can be validated together. **If banool/dictionarylib#11 is squash-merged the SHA changes and this needs repinning to the new `main` SHA before merging.**